### PR TITLE
Possibility to start for readonly tarantool instances has been added

### DIFF
--- a/spacer-scm-1.rockspec
+++ b/spacer-scm-1.rockspec
@@ -1,12 +1,12 @@
 package = 'spacer'
 version = 'scm-1'
 source  = {
-    url    = 'git://github.com/igorcoding/tarantool-spacer.git',
+    url    = 'git://github.com/andrew-statsenko/tarantool-spacer.git',
     branch = 'master',
 }
 description = {
     summary  = "Spacer for Tarantool. For managing spaces easily.",
-    homepage = 'https://github.com/igorcoding/tarantool-spacer',
+    homepage = 'https://github.com/andrew-statsenko/tarantool-spacer',
     license  = 'MIT',
 }
 dependencies = {

--- a/spacer-scm-1.rockspec
+++ b/spacer-scm-1.rockspec
@@ -1,12 +1,12 @@
 package = 'spacer'
 version = 'scm-1'
 source  = {
-    url    = 'git://github.com/andrew-statsenko/tarantool-spacer.git',
+    url    = 'git://github.com/igorcoding/tarantool-spacer.git',
     branch = 'master',
 }
 description = {
     summary  = "Spacer for Tarantool. For managing spaces easily.",
-    homepage = 'https://github.com/andrew-statsenko/tarantool-spacer',
+    homepage = 'https://github.com/igorcoding/tarantool-spacer',
     license  = 'MIT',
 }
 dependencies = {

--- a/spacer.lua
+++ b/spacer.lua
@@ -47,6 +47,7 @@ spacer.duplicate_space('space6', 'space1', {
 local log = require('log')
 local msgpack = require('msgpack')
 
+local spacer = {}
 local F = {}
 local T = {}
 
@@ -345,16 +346,30 @@ local function tuple_pack(t, f_info)
 	return box.tuple.new(tuple)
 end
 
+local function create_space_stub(new_space)
+	log.info("Skipping spacer create_space action for '%s', because database in read only mode.", new_space)
+end
+
+local function duplicate_space_stub(new_space)
+	log.info("Skipping spacer duplicate_space action for '%s', because database in read only mode.", new_space)
+end
+
 
 init_all_spaces_info()
 rawset(_G, 'F', F)
 rawset(_G, 'T', T)
 
-return {
-	F = F,
-	T = T,
-	create_space = create_space,
-	duplicate_space = duplicate_space,
-	tuple_unpack = tuple_unpack,
-	tuple_pack = tuple_pack,
-}
+spacer.F = F
+spacer.T = T
+spacer.tuple_pack = tuple_pack
+spacer.tuple_unpack = tuple_unpack
+
+if box.cfg.read_only then
+	spacer.create_space = create_space_stub
+	spacer.duplicate_space = duplicate_space_stub
+else
+	spacer.create_space = create_space
+	spacer.duplicate_space = duplicate_space
+end
+
+return spacer

--- a/spacer.lua
+++ b/spacer.lua
@@ -347,11 +347,11 @@ local function tuple_pack(t, f_info)
 end
 
 local function create_space_stub(new_space)
-	log.info("Skipping spacer create_space action for '%s', because database in read only mode.", new_space)
+	log.info("Skipping spacer create_space() action for '%s', because database in read only mode.", new_space)
 end
 
 local function duplicate_space_stub(new_space)
-	log.info("Skipping spacer duplicate_space action for '%s', because database in read only mode.", new_space)
+	log.info("Skipping spacer duplicate_space() action for '%s', because database in read only mode.", new_space)
 end
 
 


### PR DESCRIPTION
No way to start tarantool 1.7 (vinyl) in read only mode (master-replica) without this patch. 